### PR TITLE
Use a guaranteed invalid URL instead of example.com

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 function refreshPac(proxyConfig) {
     // change autoConfigUrl to dummy
     const originalUrl = proxyConfig.autoConfigUrl;
-    proxyConfig.autoConfigUrl = 'http://example.com/';
+    proxyConfig.autoConfigUrl = 'http://proxy-reload.firefox.invalid/proxy.pac';
     browser.proxy.settings.set({value: proxyConfig}).then(function (setResult) {
         // rollback
         proxyConfig.autoConfigUrl = originalUrl;


### PR DESCRIPTION
While looking at #3 I noticed that the dummy URL points to http://example.com/ which might leak some
data to this external resource.  Which shouldn't be that bad since it is run by trusted people but still.

This uses a domain below the reserved `.invalid` TLD which is guaranteed not to exist.